### PR TITLE
Add wrapper methods for getEpics and getEpicData endpoints

### DIFF
--- a/lib/zenhub.js
+++ b/lib/zenhub.js
@@ -87,4 +87,31 @@ ZenHub.prototype.getIssueEvents = function (repoId, issueNumber, callback) {
     });
 };
 
+/**
+ * Get epics for a repository
+ * This method returns an array of the repository's epics
+ * @param int   repoId      github id of repository
+ * @callback    complete
+ * @memberof    ZenHub
+ * @method      getEpics
+ */
+ZenHub.prototype.getEpics = function (repoId, callback) {
+    this._get('repositories/' + repoId + '/epics', {}, function(error, body) {
+        callback(error, body);
+    });
+};
 
+/**
+ * Show epic information
+ * This method returns all data related to an epic
+ * @param int   repoId      github id of repository
+ * @param int   epicId      github id of issue marked as an epic
+ * @callback    complete
+ * @memberof    ZenHub
+ * @method      getEpicData
+ */
+ZenHub.prototype.getEpicData = function (repoId, epicId, callback) {
+    this._get('repositories/' + repoId + '/epics/' + epicId, {}, function(error, body) {
+        callback(error, body);
+    });
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "request": "2.x"
   },
   "devDependencies": {
-    "mocha": "^2.4.5"
+    "mocha": "^3.1.0"
   }
 }

--- a/test/zenhubTest.js
+++ b/test/zenhubTest.js
@@ -29,4 +29,19 @@ describe('ZenHub API', function() {
         });
     });
 
+    describe('Board epics test', function() {
+        it('should get all epics in a board of repo', function(done) {
+            api.getEpics(config.repoId, done);
+        });
+        it('should get all data for an epic', function(done) {
+            var self = this;
+            api.getEpics(config.repoId, function(error, response) {
+                if (response.epic_issues.length === 0) {
+                    return self.skip();
+                }
+                api.getEpicData(config.repoId, response.epic_issues[0].issue_number, done);
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
This PR adds wrapper methods for the following ZenHub API endpoints:

- [Get epics for a repository](https://github.com/ZenHubIO/API#get-epics-for-a-repository)
- [Get epic data](https://github.com/ZenHubIO/API#get-epic-data)

Please note that I've added a conditional `skip()` in the test for `getEpicData`, because not all repositories will contain epics and other developers may not have access to repositories that do (for use in their `test/config.json`). This necessitated upgrading `mocha` to `v3` (see https://github.com/mochajs/mocha/pull/2335).