### PR TITLE
Two write API wrappers

### DIFF
--- a/lib/zenhub.js
+++ b/lib/zenhub.js
@@ -64,9 +64,6 @@ ZenHub.prototype._post = function(url, parameters, body, callback) {
         json: true,
         body: body,
     }, function(error, response, body) {
-        if (!error && !!body.status && body.status !== 'OK') {
-            error = new Error(body.description || body.error_message);
-        }
         callback(error, body || {});
     });
 };

--- a/lib/zenhub.js
+++ b/lib/zenhub.js
@@ -44,6 +44,34 @@ ZenHub.prototype._get = function(url, parameters, callback) {
 };
 
 /**
+ * Helper to handle POST requests to the API with authorization
+ *
+ * @private
+ * @param string    url             address part after API root
+ * @param object    parameters      additional parameters
+ * @param object    body            request body
+ * @callback        complete
+ * @memberof        ZenHub
+ * @method          get
+ */
+ZenHub.prototype._post = function(url, parameters, body, callback) {
+    parameters = extend(parameters, this.credentials); // Add credentials to parameters
+    var postURL = API_URL + '/' + url + '?' + querystring.stringify(parameters); // Construct URL with parameters
+
+    request.post({
+        url: postURL,
+        strictSSL: true,
+        json: true,
+        body: body,
+    }, function(error, response, body) {
+        if (!error && !!body.status && body.status !== 'OK') {
+            error = new Error(body.description || body.error_message);
+        }
+        callback(error, body || {});
+    });
+};
+
+/**
  * Show All Pipelines in a repo board
  * This method returns all pipelines in a repo board
  * @param int   repoId      github id of repository

--- a/lib/zenhub.js
+++ b/lib/zenhub.js
@@ -143,3 +143,19 @@ ZenHub.prototype.getEpicData = function (repoId, epicId, callback) {
         callback(error, body);
     });
 };
+
+/**
+ * Add and/or remove issues to an epic
+ * This method updates the ZenHub metadata for the epic
+ * @param int   repoId      github id of repository
+ * @param int   epicId      github id of issue marked as an epic
+ * @param object    payload      instructions for which issues to move, see https://github.com/ZenHubIO/API#add-or-remove-issues-to-epic for payload format
+ * @callback    complete
+ * @memberof    ZenHub
+ * @method      addRemoveIssuesToEpic
+ */
+ZenHub.prototype.addRemoveIssuesToEpic = function (repoId, epicId, payload, callback) {
+    this._post('repositories/' + repoId + '/epics/' + epicId + '/update_issues', {}, payload, function (error, body) {
+        callback(error, body);
+    });
+};

--- a/lib/zenhub.js
+++ b/lib/zenhub.js
@@ -156,3 +156,19 @@ ZenHub.prototype.addRemoveIssuesToEpic = function (repoId, epicId, payload, call
         callback(error, body);
     });
 };
+
+/**
+ * Convert issue to an epic
+ * This method converts an issue to an epic on ZenHub. A list of issues to move to the new epic may optionally be specified.
+ * @param int   repoId      github id of repository
+ * @param int   issueId      github id of issue to convert
+ * @param object    payload      contains list of issues to move to the epic, see https://github.com/ZenHubIO/API#convert-issue-to-epic for payload format
+ * @callback    complete
+ * @memberof    ZenHub
+ * @method      convertIssueToEpic
+ */
+ZenHub.prototype.convertIssueToEpic = function (repoId, issueId, payload, callback) {
+    this._post('repositories/' + repoId + '/issues/' + issueId + '/convert_to_epic', {}, payload, function (error, body) {
+        callback(error, body);
+    });
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "request": "2.x"
   },
   "devDependencies": {
-    "mocha": "^3.1.0"
+    "mocha": "^3.1.0",
+    "nock": "^9.0.11"
   }
 }

--- a/test/zenhubReadTest.js
+++ b/test/zenhubReadTest.js
@@ -7,7 +7,7 @@ var path = require('path');
 
 var config = JSON.parse(fs.readFileSync(path.normalize(__dirname + '/config.json', 'utf8')));
 
-describe('ZenHub API', function() {
+describe('ZenHub Read API', function() {
     var Zenhub = require('../lib/zenhub');
     var api = new Zenhub(config.token);
 

--- a/test/zenhubWriteTest.js
+++ b/test/zenhubWriteTest.js
@@ -3,7 +3,6 @@ var nock = require('nock');
 
 var token = 'token';
 var repoId = 9876;
-var epicId = 123;
 var tokenQueryString = '?access_token=' + token;
 
 describe('ZenHub Write API', function() {
@@ -15,6 +14,8 @@ describe('ZenHub Write API', function() {
     });
 
     describe('Add/remove issues to epic test', function() {
+        var epicId = 123;
+
         it('should send payload to the ZenHub API', function(done) {
             var payload = {
                 remove_issues: [
@@ -38,6 +39,29 @@ describe('ZenHub Write API', function() {
                 .post('/repositories/' + repoId + '/epics/' + epicId + '/update_issues' + tokenQueryString, payload)
                 .reply(200, { status: 'OK' });
             api.addRemoveIssuesToEpic(repoId, epicId, payload, done);
+       });
+    });
+
+    describe('Convert issue to epic test', function() {
+        var issueId = 456;
+
+        it('should send payload to the ZenHub API', function(done) {
+            var payload = {
+                issues: [
+                    {
+                        repo_id: 13550592,
+                        issue_number: 3
+                    },
+                    {
+                        repo_id: 13550592,
+                        issue_number: 1
+                    }
+                ]
+            };
+            nock('https://api.zenhub.io/p1')
+                .post('/repositories/' + repoId + '/issues/' + issueId + '/convert_to_epic' + tokenQueryString, payload)
+                .reply(200, { status: 'OK' });
+            api.convertIssueToEpic(repoId, issueId, payload, done);
        });
     });
 });

--- a/test/zenhubWriteTest.js
+++ b/test/zenhubWriteTest.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+var nock = require('nock');
+
+var token = 'token';
+var repoId = 9876;
+var epicId = 123;
+var tokenQueryString = '?access_token=' + token;
+
+describe('ZenHub Write API', function() {
+    var Zenhub = require('../lib/zenhub');
+    var api = new Zenhub(token);
+
+    afterEach(function() {
+        assert(nock.isDone(), 'not all expected HTTP requests were made');
+    });
+
+    describe('Add/remove issues to epic test', function() {
+        it('should send payload to the ZenHub API', function(done) {
+            var payload = {
+                remove_issues: [
+                    {
+                        repo_id: repoId,
+                        issue_number: 3
+                    }
+                ],
+                add_issues: [
+                    {
+                        repo_id: repoId,
+                        issue_number: 2
+                    },
+                    {
+                        repo_id: repoId,
+                        issue_number: 1
+                    }
+                ]
+            };
+            nock('https://api.zenhub.io/p1')
+                .post('/repositories/' + repoId + '/epics/' + epicId + '/update_issues' + tokenQueryString, payload)
+                .reply(200, { status: 'OK' });
+            api.addRemoveIssuesToEpic(repoId, epicId, payload, done);
+       });
+    });
+});


### PR DESCRIPTION
The ZenHub folks have recently added some [Write API Endpoints](https://www.zenhub.com/blog/write-api-and-velocity-chart-enhancements/).

This Pull Request adds wrapper methods for two of these methods:
- `addRemoveIssuesToEpic` - https://github.com/ZenHubIO/API#add-or-remove-issues-to-epic
- `convertIssueToEpic` - https://github.com/ZenHubIO/API#convert-issue-to-epic

Notes:
- The write API tests (which I've placed in a separate file) rely on mocked HTTP responses, rather than writing to a real ZenHub board
- I've opted to take the whole JSON `payload` as an argument to the two write methods, because this will allow consumers the flexibility to construct these themselves